### PR TITLE
build(pip): use Python 3.12

### DIFF
--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -10,6 +10,7 @@ jobs:
     uses: coatl-dev/workflows/.github/workflows/pip-compile-upgrade.yml@v4
     with:
       path: requirements.txt
+      python-version: '3.12'
     secrets:
       gh-token: ${{ secrets.COATL_BOT_GH_TOKEN }}
       gpg-sign-passphrase: ${{ secrets.COATL_BOT_GPG_PASSPHRASE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,5 +15,7 @@ jobs:
     needs:
       - tox
     uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4
+    with:
+      python-version: '3.12'
     secrets:
       password: ${{ secrets.PYPI_API_TOKEN_INCENDIUM_STUBS }}


### PR DESCRIPTION
for:
- building and pushing to PyPI
- upgrading requirements file (pip-compile)
